### PR TITLE
Added tmux-mighty-scroll

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ A list of tmux plugins.
 - [tmux-mem-cpu-load](https://github.com/thewtex/tmux-mem-cpu-load) - CPU, RAM,
   and load monitor for use with tmux.
 - [tmux-menus](https://github.com/jaclu/tmux-menus) - Popup menus to handle commands that are hard to remember, and some custom actions.
+- [tmux-mighty-scroll](https://github.com/noscript/tmux-mighty-scroll) - Seamless mouse scroll.
 - [tmux-mode-indicator](https://github.com/MunifTanjim/tmux-mode-indicator) - Displays prompt indicating currently active Tmux mode.
 - [tmux-mouse-swipe](https://github.com/jaclu/tmux-mouse-swipe) - Switch Window or Session by clicking right mouse button and swiping.
 - [tmux-net-speed](https://github.com/tmux-plugins/tmux-net-speed) - Tmux


### PR DESCRIPTION
Allows using mouse for scrolling tmux panes or passing scroll evens through to running processes.