### PR TITLE
New plugin tmux-power-zoom

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ Pro tip: watch this repository to get notified about new plugins.
 - [tmux-pomodoro](https://github.com/swaroopch/tmux-pomodoro) - Use Pomodoro
   technique with timer showing in tmux status bar.
 - [tmux-pomodoro-plus](https://github.com/olimorris/tmux-pomodoro-plus) - A fork of tmux-pomodoro with more options and greater adherence to the technique.
+- [tmux-power-zoom](https://github.com/jaclu/tmux-power-zoom) - Zoom pane to separate window, then unzoom it back into it's original location.
 - [tmux-prefix-highlight](https://github.com/tmux-plugins/tmux-prefix-highlight)
   Plugin that highlights when you press tmux prefix key.
 - [tmux-resurrect](https://github.com/tmux-plugins/tmux-resurrect) - Persists


### PR DESCRIPTION
Zoom pane to separate window, and unzoom back into the original location.

This way you can open other panes whilst focusing on the zoomed pane, without risking getting a crowded mess of panes.