### PR TITLE
feat: add tmux-notify to plugin list

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Pro tip: watch this repository to get notified about new plugins.
   plugin to monitor upload and download speed of one or all interfaces.
 - [tmux-newsboat](https://github.com/tmux-plugins/tmux-newsboat) - Display
   [newsboat](https://newsboat.org) counters in tmux status line.
+- [tmux-notify](https://github.com/ChanderG/tmux-notify) - Tmux plugin to notify you when processes complete.
 - [tmux-now-playing](https://github.com/spywhere/tmux-now-playing) -
   Showing currently playing track in tmux status bar with music controls.
 - [tmux-online-status](https://github.com/tmux-plugins/tmux-online-status) -


### PR DESCRIPTION
Adds the [tmux-notify](https://github.com/ChanderG/tmux-notify) plugin to the plugin list to make it easier for people to find. As explained in https://github.com/ChanderG/tmux-notify/issues/16 we are also happy to transfer this plugin to the [tmux-plugins](https://github.com/tmux-plugins) organization so that it is easier to maintain. 