### PR TITLE
Adding tmux-ip-address plugin to the tmux-plugins list.

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,4 +98,4 @@ Pro tip: watch this repository to get notified about new plugins.
 - [tmux-yank](https://github.com/tmux-plugins/tmux-yank) - Plugin for copying
   to system clipboard. Works on MacOS, Linux and Cygwin.
 - [tpm](https://github.com/tmux-plugins/tpm) - Tmux plugin manager.
-- [tmux-ip-address](https://github.com/tmux-ip-address) - Plugin for show public IP on status bar of tmux.
+- [tmux-ip-address](https://github.com/anghootys/tmux-ip-address) - Plugin for show public IP on status bar of tmux.

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Pro tip: watch this repository to get notified about new plugins.
   on your terminal window in your $EDITOR of choice!
 - [tmux-fzf](https://github.com/sainnhe/tmux-fzf) - Use fzf to manage tmux environment.
 - [tmux-fzf-session-switch](https://github.com/thuanpham2311/tmux-fzf-session-switch) - Open or create a tmux session with fzf with a popup menu.
+- [tmux-ip-address](https://github.com/anghootys/tmux-ip-address) - Plugin for show public IP on status bar.
 - [tmux-jump](https://github.com/schasse/tmux-jump) - Vimium/Easymotion like
   navigation for tmux.
 - [tmux-keyboard-layout](https://github.com/imomaliev/tmux-keyboard-layout) - Show current keyboard layout in your status bar
@@ -98,4 +99,3 @@ Pro tip: watch this repository to get notified about new plugins.
 - [tmux-yank](https://github.com/tmux-plugins/tmux-yank) - Plugin for copying
   to system clipboard. Works on MacOS, Linux and Cygwin.
 - [tpm](https://github.com/tmux-plugins/tpm) - Tmux plugin manager.
-- [tmux-ip-address](https://github.com/anghootys/tmux-ip-address) - Plugin for show public IP on status bar of tmux.

--- a/README.md
+++ b/README.md
@@ -98,3 +98,4 @@ Pro tip: watch this repository to get notified about new plugins.
 - [tmux-yank](https://github.com/tmux-plugins/tmux-yank) - Plugin for copying
   to system clipboard. Works on MacOS, Linux and Cygwin.
 - [tpm](https://github.com/tmux-plugins/tpm) - Tmux plugin manager.
+- [tmux-ip-address](https://github.com/tmux-ip-address) - Plugin for show public IP on status bar of tmux.


### PR DESCRIPTION
[tmux-ip-address](https://github.com/anghootys/tmux-ip-address) is a plugin that shows public IP address on the status bar of tmux.