### PR TITLE
feat: add tmux-nested

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ A list of tmux plugins.
 - [tmux-continuum](https://github.com/tmux-plugins/tmux-continuum) - Continuous saving of tmux environment. Automatic restore when tmux is started. Automatic tmux start when computer is turned on.
 - [tmux-fzf-session-switch](https://github.com/thuanpham2311/tmux-fzf-session-switch) - Open or create a tmux session with fzf with a popup menu.
 - [tmux-named-snapshot](https://github.com/spywhere/tmux-named-snapshot) - A tmux-resurrect extension for named snapshot support. Save and restore multiple snapshots to your will.
+- [tmux-nested](https://github.com/niqodea/tmux-nested) - Alternative to [tmux-suspend](https://github.com/MunifTanjim/tmux-suspend), supports arbitrary levels of nesting.
 - [tmux-resurrect](https://github.com/tmux-plugins/tmux-resurrect) - Persists tmux environment across system restarts.
 - [tmux-session-wizard](https://github.com/27medkamal/tmux-session-wizard) - One prefix to control all your session creation, naming, switching, etc using [fzf](https://github.com/junegunn/fzf) & [zoxide](https://github.com/ajeetdsouza/zoxide)
 - [tmux-sessionist](https://github.com/tmux-plugins/tmux-sessionist) - Lightweight utils for manipulating sessions.


### PR DESCRIPTION
[tmux-nested](https://github.com/niqodea/tmux-nested) is an alternative to [tmux-suspend](https://github.com/MunifTanjim/tmux-suspend) that supports arbitrary levels of nesting.