### PR TITLE
Add tmux-code-time plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ A list of tmux plugins.
 - [tmux-aws-vault](https://github.com/mateimicu/tmux-aws-vault) - Display current aws-vault context and time remaining in the session.
 - [tmux-battery](https://github.com/tmux-plugins/tmux-battery) - Plug and play battery percentage and icon indicator.
 - [tmux-bitahub](https://github.com/Freed-Wu/tmux-bitahub) - Display GPU status of [bitahub](https://www.bitahub.com/) in status bar of tmux
+- [tmux-code-time](https://github.com/theo64oliver/tmux-code-time) - Tracks time spent in sessions. Displays session duration in your status bar.
 - [tmux-cpu](https://github.com/tmux-plugins/tmux-cpu) - Plug and play cpu percentage and icon indicator.
 - [tmux-df](https://github.com/tassaron/tmux-df) - Output of `df` in the status bar
 - [tmux-digit](https://github.com/Freed-Wu/tmux-digit) - Display digit signs (⓪ ① ② ③ ④ ⑤ ⑥ ⑦ ⑧ ⑨ ⑩ ⑪ ⑫ ⑬ ⑭ ⑮ ⑯ ⑰ ⑱ ⑲ ⑳) in status bar of tmux


### PR DESCRIPTION
This plugin tracks the time spent in tmux sessions, displaying session duration to help users monitor their workflow.

- Plugin is currently in its initial version with the basic feature: displaying the time of the current session.
- Future updates will include additional features for enhanced workflow tracking.

GitHub repository: https://github.com/theo64oliver/tmux-code-time