### PR TITLE
Add vanzi-tmux-theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,3 +120,4 @@ A list of tmux plugins.
 - [tmux-nord-plusplus](https://github.com/Wabri/tmux-nord-plusplus) - An arctic, north-bluish clean and elegant tmux color theme with support for battery & pomodoro.
 - [tmux-peacock](https://github.com/imomaliev/tmux-peacock) - Per session color and style based on session name
 - [rose-pine](https://github.com/rose-pine/tmux) - All natural pine, faux fur and a bit of soho vibes for the classy minimalist for tmux.
+- [vanzi](https://github.com/tarquibrian/vanzi) - Clean and minimalist tmux theme.


### PR DESCRIPTION
This PR introduces the Vanzi Tmux Theme, a clean and minimal theme for tmux with the following features:

- Light (ivory) and dark (vanzi) variants
- Optional background transparency
- Highlighted active pane border

Preview:
<img width="961" height="33" alt="vanzi-dark" src="https://github.com/user-attachments/assets/702891a0-db17-41ec-bf42-a603ff9e3468" />
<img width="964" height="32" alt="ivory-light" src="https://github.com/user-attachments/assets/eae5d2a2-736d-4a61-be9d-f1e094cd27e0" />
