### PR TITLE
Add tmux-opencode-usage to Status Bar section

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ A list of tmux plugins.
 - [tmux-newsboat](https://github.com/tmux-plugins/tmux-newsboat) - Display [newsboat](https://newsboat.org) counters in tmux status line.
 - [tmux-now-playing](https://github.com/spywhere/tmux-now-playing) - Showing currently playing track in tmux status bar with music controls.
 - [tmux-online-status](https://github.com/tmux-plugins/tmux-online-status) - Tmux plugin that displays online status of your computer.
+- [tmux-opencode-usage](https://github.com/0x3k/tmux-opencode-usage) - Live opencode AI usage in the status bar — prompts sent and tokens consumed, sourced directly from the local database.
 - [tmux-packet-loss](https://github.com/jaclu/tmux-packet-loss) - Displays packet loss % if at or above the specified threshold level.
 - [tmux-piavpn](https://github.com/Brutuski/tmux-piavpn) - Keep track of your [Private Internet Access](https://www.privateinternetaccess.com/) VPN status.
 - [tmux-ping](https://github.com/ayzenquwe/tmux-ping) - Shows an average ping latency to a specified host.


### PR DESCRIPTION
## Description

Adds [tmux-opencode-usage](https://github.com/0x3k/tmux-opencode-usage) to the Status Bar section.

This plugin shows live [opencode](https://opencode.ai) AI usage in the tmux status bar — prompts sent and tokens consumed — by querying opencode's local SQLite database directly. No API keys or network requests required.

**Features:**
- Adaptive polling: 2s refresh on activity, backs off to 60s when idle
- Configurable time window: from midnight today (default) or rolling 24h
- Works standalone or as a catppuccin-themed module
- Dependencies: `sqlite3` and `awk` only