### PR TITLE
doc: add claude-usage status bar plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ A list of tmux plugins.
 - [tmux-aws-vault](https://github.com/mateimicu/tmux-aws-vault) - Display current aws-vault context and time remaining in the session.
 - [tmux-battery](https://github.com/tmux-plugins/tmux-battery) - Plug and play battery percentage and icon indicator.
 - [tmux-bitahub](https://github.com/Freed-Wu/tmux-bitahub) - Display GPU status of [bitahub](https://www.bitahub.com/) in status bar of tmux
+- [tmux-claude-usage](https://github.com/robhurring/tmux-claude-usage) - Show Claude Code rate limits, cost, and model in your tmux status bar.
 - [tmux-cpu](https://github.com/tmux-plugins/tmux-cpu) - Plug and play cpu percentage and icon indicator.
 - [tmux-df](https://github.com/tassaron/tmux-df) - Output of `df` in the status bar
 - [tmux-digit](https://github.com/Freed-Wu/tmux-digit) - Display digit signs (⓪ ① ② ③ ④ ⑤ ⑥ ⑦ ⑧ ⑨ ⑩ ⑪ ⑫ ⑬ ⑭ ⑮ ⑯ ⑰ ⑱ ⑲ ⑳) in status bar of tmux


### PR DESCRIPTION
YAVCP - yet another vibe coded plugin

MITM's claude code's stauts line hook, caches the json and makes it available as a tmux-status line plugin. highly configurable, includes tests (that pass!) to pretend its not vibe coded, but it is a very thoughtful plugin that works well and is pretty 😉 

<img width="745" height="54" alt="image" src="https://github.com/user-attachments/assets/42bad118-c481-4d79-b2c7-3542d984d623" />




**README:** https://github.com/robhurring/tmux-claude-usage