### PR TITLE
Add tmux-protonvpn

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ A list of tmux plugins.
 - [tmux-pomodoro](https://github.com/swaroopch/tmux-pomodoro) - Use Pomodoro technique with timer showing in tmux status bar.
 - [tmux-powerline](https://github.com/erikw/tmux-powerline) - A hackable status bar consisting of dynamic & beautiful looking powerline segments, written purely in bash.
 - [tmux-prefix-highlight](https://github.com/tmux-plugins/tmux-prefix-highlight) Plugin that highlights when you press tmux prefix key.
+- [tmux-protonvpn](https://github.com/kidesleo/tmux-protonvpn) - Adds an indicator for your Proton VPN connection status.
 - [tmux-session-dots](https://github.com/jtmcginty/tmux-session-dots) - Visual session indicator showing all sessions as dots with the current session highlighted.
 - [tmux-spotify-tui](https://github.com/alexchaichan/tmux-spotify-tui) - Plugin that shows current playing song with [Spotify-TUI](https://github.com/Rigellute/spotify-tui).
 - [tmux-ticker](https://github.com/Brutuski/tmux-ticker) - Keep a track of popular market indexes and stock price.


### PR DESCRIPTION
## Summary
- Adds [tmux-protonvpn](https://github.com/kidesleo/tmux-protonvpn) to the Status Bar section
- Adds an indicator for Proton VPN connection status 

<img width="637" height="62" alt="image" src="https://github.com/user-attachments/assets/38545c54-2693-4005-a96b-5f80fd2994fc" />

---
Thanks for the list!