### PR TITLE
Add codex-tmux-sentinel

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ A list of tmux plugins.
 
 
 ## Status Bar
+- [codex-tmux-sentinel](https://github.com/MartinKoubek/codex-tmux-sentinel) - Show Codex activity next to each tmux window name.
 - [tmux2k](https://github.com/2KAbhishek/tmux2k) - Highly customizable tmux status bar framework, providing you with a sleek and informative status bar.
 - [tmux-acpi](https://github.com/briansalehi/tmux-acpi) - Display ACPI information including thermal status, battery health, battery percentage, and adapter status.
 - [tmux-aws-vault](https://github.com/mateimicu/tmux-aws-vault) - Display current aws-vault context and time remaining in the session.


### PR DESCRIPTION
Adds codex-tmux-sentinel to the Status Bar section.

The plugin shows Codex activity indicators next to tmux window names.