### PR TITLE
Add tmux-agent-status to Status Bar section

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ A list of tmux plugins.
 ## Status Bar
 - [tmux2k](https://github.com/2KAbhishek/tmux2k) - Highly customizable tmux status bar framework, providing you with a sleek and informative status bar.
 - [tmux-acpi](https://github.com/briansalehi/tmux-acpi) - Display ACPI information including thermal status, battery health, battery percentage, and adapter status.
+- [tmux-agent-status](https://github.com/JanSuthacheeva/tmux-agent-status) - Show the state of your AI coding agents (Claude Code, Codex CLI, ...) per window and across sessions: working, waiting, or idle.
 - [tmux-aws-vault](https://github.com/mateimicu/tmux-aws-vault) - Display current aws-vault context and time remaining in the session.
 - [tmux-battery](https://github.com/tmux-plugins/tmux-battery) - Plug and play battery percentage and icon indicator.
 - [tmux-bitahub](https://github.com/Freed-Wu/tmux-bitahub) - Display GPU status of [bitahub](https://www.bitahub.com/) in status bar of tmux


### PR DESCRIPTION
Adds [tmux-agent-status](https://github.com/JanSuthacheeva/tmux-agent-status) to the Status Bar section.

It shows the state of AI coding agents (Claude Code, Codex CLI, ...) in the tmux status line: a per-window state dot (working / waiting / idle) and a cross-session summary. TPM-installable with a standard `.tmux` entry point.