### PR TITLE
Add showy-quota

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ A list of tmux plugins.
 
 
 ## Status Bar
+- [showy-quota](https://github.com/enieuwy/showy-quota) - Status-right quota strip for Claude, Codex, and 50+ other AI providers, driven by CodexBar.
 - [tmux2k](https://github.com/2KAbhishek/tmux2k) - Highly customizable tmux status bar framework, providing you with a sleek and informative status bar.
 - [tmux-acpi](https://github.com/briansalehi/tmux-acpi) - Display ACPI information including thermal status, battery health, battery percentage, and adapter status.
 - [tmux-aws-vault](https://github.com/mateimicu/tmux-aws-vault) - Display current aws-vault context and time remaining in the session.


### PR DESCRIPTION
Adds [showy-quota](https://github.com/enieuwy/showy-quota) to the Status Bar section — a status-right quota strip for Claude, Codex, and 50+ other AI providers, driven by CodexBar.TPM-installable: `set -g @plugin 'enieuwy/showy-quota'` (`showy-quota.tmux` at repo root). I'm the author.