### PR TITLE
Add slate

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ A list of tmux plugins.
 ## Themes
 - [catppuccin](https://github.com/catppuccin/tmux) - A soothing pastel theme for tmux.
 - [dracula](https://github.com/dracula/tmux) - 🧛🏻‍♂️ Dark theme for tmux
+- [slate](https://github.com/adarshba/slate) - Dark and Light theme for tmux, auto-switching.
 - [tmux-colors-solarized](https://github.com/seebi/tmux-colors-solarized) - A solarized theme for tmux.
 - [tmux-colours-superhero](https://github.com/leighmcculloch/tmux-colours-superhero) - A superhero themed tmux colour theme.
 - [tmux-dark-notify](https://github.com/erikw/tmux-dark-notify) - Make tmux's theme follow macOS dark/light mode.


### PR DESCRIPTION
Adds [slate](https://github.com/adarshba/slate) to the Themes section.

- Dark and Light variants
- Auto-detects macOS system appearance (`auto` default)
- Live toggle with `prefix + T`
- No dependencies, no nerd fonts required
- Single bash script, one `tmux` call