### PR TITLE
Add tmux-codex-auto-continue

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ A list of tmux plugins.
 - [tmux-autoreload](https://github.com/b0o/tmux-autoreload) - Watches your tmux configuration file and automatically reloads it on change.
 - [tmux-browser](https://github.com/ofirgall/tmux-browser) - Web browser sessions attached to tmux sessions.
 - [tmux-cargo](https://github.com/idevtier/tmux-cargo) - Plugin for executing cargo commands
+- [tmux-codex-auto-continue](https://github.com/yeahdongcn/tmux-codex-auto-continue) - Safely resumes interrupted Codex CLI turns and selected retry/wait states.
 - [tmux-cowboy](https://github.com/tmux-plugins/tmux-cowboy) - Kill hanging processes fast.
 - [tmux-devcontainers](https://github.com/phil/tmux-devcontainers) - Manage and interact with (Devcontainers)[https://containers.dev]
 - [tmux-floating-plugin](https://github.com/lloydbond/tmux-floating-terminal) - A popup floating terminal window in tmux.


### PR DESCRIPTION
Adds [tmux-codex-auto-continue](https://github.com/yeahdongcn/tmux-codex-auto-continue), a TPM-compatible watcher that safely resumes interrupted Codex CLI turns and selected retry/wait states.

It is distinct from a status indicator or completion loop: normal completed turns are ignored, and input is sent only after strict process, prompt, and pane-state checks.