### PR TITLE
Add tmux-agent-state

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ A list of tmux plugins.
 ## Status Bar
 - [tmux2k](https://github.com/2KAbhishek/tmux2k) - Highly customizable tmux status bar framework, providing you with a sleek and informative status bar.
 - [tmux-acpi](https://github.com/briansalehi/tmux-acpi) - Display ACPI information including thermal status, battery health, battery percentage, and adapter status.
+- [tmux-agent-state](https://github.com/cburmeister/tmux-agent-state) - Agent state (working, blocked, done) on your window tabs, driven by lifecycle events from Claude Code, Codex, and OpenCode.
 - [tmux-aws-vault](https://github.com/mateimicu/tmux-aws-vault) - Display current aws-vault context and time remaining in the session.
 - [tmux-battery](https://github.com/tmux-plugins/tmux-battery) - Plug and play battery percentage and icon indicator.
 - [tmux-bitahub](https://github.com/Freed-Wu/tmux-bitahub) - Display GPU status of [bitahub](https://www.bitahub.com/) in status bar of tmux

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ A list of tmux plugins.
 ## Status Bar
 - [tmux2k](https://github.com/2KAbhishek/tmux2k) - Highly customizable tmux status bar framework, providing you with a sleek and informative status bar.
 - [tmux-acpi](https://github.com/briansalehi/tmux-acpi) - Display ACPI information including thermal status, battery health, battery percentage, and adapter status.
-- [tmux-agent-state](https://github.com/cburmeister/tmux-agent-state) - Agent state (working, blocked, done) on your window tabs, driven by lifecycle events from Claude Code, Codex, and OpenCode.
+- [tmux-agent-state](https://github.com/cburmeister/tmux-agent-state) - Agent state on your tmux window tabs. For people who already live in tmux and run coding agents in it.
 - [tmux-aws-vault](https://github.com/mateimicu/tmux-aws-vault) - Display current aws-vault context and time remaining in the session.
 - [tmux-battery](https://github.com/tmux-plugins/tmux-battery) - Plug and play battery percentage and icon indicator.
 - [tmux-bitahub](https://github.com/Freed-Wu/tmux-bitahub) - Display GPU status of [bitahub](https://www.bitahub.com/) in status bar of tmux


### PR DESCRIPTION
Adds [tmux-agent-state](https://github.com/cburmeister/tmux-agent-state) to the Status Bar section.

Agent state on your tmux window tabs: a marker per window for working / blocked / done, driven by the agents' own lifecycle events (Claude Code, Codex, OpenCode adapters) rather than screen scraping. MIT licensed, installs with TPM.