### PR TITLE
Add tmux-agent-signal

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ A list of tmux plugins.
 ## Status Bar
 - [tmux2k](https://github.com/2KAbhishek/tmux2k) - Highly customizable tmux status bar framework, providing you with a sleek and informative status bar.
 - [tmux-acpi](https://github.com/briansalehi/tmux-acpi) - Display ACPI information including thermal status, battery health, battery percentage, and adapter status.
+- [tmux-agent-signal](https://github.com/jward7/tmux-agent-signal) - Show which windows have an AI coding agent that is working, blocked on you, or done; driven by Claude Code hooks, no daemon or polling.
 - [tmux-aws-vault](https://github.com/mateimicu/tmux-aws-vault) - Display current aws-vault context and time remaining in the session.
 - [tmux-battery](https://github.com/tmux-plugins/tmux-battery) - Plug and play battery percentage and icon indicator.
 - [tmux-bitahub](https://github.com/Freed-Wu/tmux-bitahub) - Display GPU status of [bitahub](https://www.bitahub.com/) in status bar of tmux


### PR DESCRIPTION
Adds [tmux-agent-signal](https://github.com/jward7/tmux-agent-signal) to the Status Bar section, in alphabetical order.

It shows, per window, whether an AI coding agent is working, blocked on a permission, asking a question, or finished, as a badge and tab colour in the window list, plus a one-glyph-per-agent summary in status-right. State comes from the agent's own lifecycle hooks (Claude Code out of the box, any agent via a one-line `set` command) written to tmux user options, so there is no daemon and nothing runs on redraw. Also has a next-needs-you key, wait/park triage, and an fzf switcher.

MIT, tested on tmux 3.5 and 3.7, CI on Ubuntu and macOS.